### PR TITLE
Disable @typescript-eslint/no-var-requires because it can be useful

### DIFF
--- a/eslint-config/pxb-rules.js
+++ b/eslint-config/pxb-rules.js
@@ -6,6 +6,7 @@ const pxbRules = {
     '@typescript-eslint/no-array-constructor':          'off',
     '@typescript-eslint/no-explicit-any':               'off',
     '@typescript-eslint/no-require-imports':            'off',
+    '@typescript-eslint/no-var-requires':               'off',
     '@typescript-eslint/no-unnecessary-condition':      'off',
     '@typescript-eslint/no-unnecessary-qualifier':      'error',
     '@typescript-eslint/no-unnecessary-type-arguments': 'error',


### PR DESCRIPTION
<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
Changes proposed in this Pull Request:
- Disable a rule, this has been ignored inline and overwritten in eslint-configs in multiple projects; let's just update it here.
