### PR TITLE
Disable no floating promises rule & explicit module boundary rule

### DIFF
--- a/eslint-config/pxb-rules.js
+++ b/eslint-config/pxb-rules.js
@@ -34,6 +34,8 @@ const pxbRules = {
             "format": ["PascalCase"]
         }
     ],
+    '@typescript-eslint/no-floating-promises': 'off',
+    '@typescript-eslint/explicit-module-boundary-types': 'off',
     '@typescript-eslint/no-array-constructor': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/no-require-imports': 'off',

--- a/eslint-config/pxb-rules.js
+++ b/eslint-config/pxb-rules.js
@@ -34,7 +34,7 @@ const pxbRules = {
             "format": ["PascalCase"]
         }
     ],
-    '@typescript-eslint/no-floating-promises': 'off',
+    '@typescript-eslint/no-floating-promises': 'error',
     '@typescript-eslint/explicit-module-boundary-types': 'error',
     '@typescript-eslint/no-array-constructor': 'off',
     '@typescript-eslint/no-explicit-any': 'off',

--- a/eslint-config/pxb-rules.js
+++ b/eslint-config/pxb-rules.js
@@ -6,7 +6,8 @@ const pxbRules = {
         "error",
         {
             "selector": "default",
-            "format": ["camelCase"]
+            "format": ["camelCase"],
+            "leadingUnderscore": "allow"
         },
         {
             "selector": "variable",

--- a/eslint-config/pxb-rules.js
+++ b/eslint-config/pxb-rules.js
@@ -6,8 +6,7 @@ const pxbRules = {
         "error",
         {
             "selector": "default",
-            "format": ["camelCase"],
-            "leadingUnderscore": "allow"
+            "format": ["camelCase"]
         },
         {
             "selector": "variable",

--- a/eslint-config/pxb-rules.js
+++ b/eslint-config/pxb-rules.js
@@ -35,7 +35,7 @@ const pxbRules = {
         }
     ],
     '@typescript-eslint/no-floating-promises': 'off',
-    '@typescript-eslint/explicit-module-boundary-types': 'off',
+    '@typescript-eslint/explicit-module-boundary-types': 'error',
     '@typescript-eslint/no-array-constructor': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/no-require-imports': 'off',


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #22 

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request
- Modifies @typescript-eslint/explicit-module-boundary-types to report an error instead of a warning.
- Disables @typescript-eslint/no-floating-promises rule.

It seems like the leading underscore syntax when injecting services in angular is getting more popular.  Syntax below:

`constructor(private _router: Router) ... `

The new version of @typescript-eslint is disregarding our @typescript-eslint/naming-convention parameter overrides and is requiring a leading underscore when we inject a service.  I think it might be a good time for us to adopt the leading underscore syntax when we inject our services.  


