### PR TITLE
We want to use any, sometimes

### DIFF
--- a/eslint-config/pxb-rules.js
+++ b/eslint-config/pxb-rules.js
@@ -35,7 +35,7 @@ const pxbRules = {
         }
     ],
     '@typescript-eslint/no-floating-promises': 'error',
-    '@typescript-eslint/explicit-module-boundary-types': 'error',
+    '@typescript-eslint/explicit-module-boundary-types': ['error', { allowArgumentsExplicitlyTypedAsAny: true }],
     '@typescript-eslint/no-array-constructor': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/no-require-imports': 'off',

--- a/eslint-config/pxb-rules.js
+++ b/eslint-config/pxb-rules.js
@@ -56,6 +56,7 @@ const pxbRules = {
     '@typescript-eslint/restrict-plus-operands': 'error',
     '@typescript-eslint/unbound-method': 'off',
     '@typescript-eslint/ban-ts-comment': 'off',
+    '@typescript-eslint/restrict-template-expressions': ['error', { allowAny: true }],
     'default-case': 'error',
     'eqeqeq': 'error',
     'no-alert': 'error',


### PR DESCRIPTION
<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Allow any in function params
- Ease restriction when type-checking variables used in templates

`restrict-template-expressions` is a real annoyance because when we create a string using a variable, that variable can only be typed `string`.   This rule can be bypassed by explicitly casting the variable in question to a string. 

 The following gives an error, since `story` is typed any: 

`<div style="box-sizing: border-box; height: 100%;">${story.template}</div>`

This is corrected by casting to a string: 
`<div style="box-sizing: border-box; height: 100%;">${story.template as string}</div>`

which doesn't really seem to add any value in my eyes.  
