### PR TITLE
Change rules for enumMember, use UPPER_CASE format

### DIFF
--- a/eslint-config/pxb-rules.js
+++ b/eslint-config/pxb-rules.js
@@ -17,11 +17,14 @@ const pxbRules = {
             "format": ["camelCase", "UPPER_CASE", "PascalCase"]
         },
         {
+            "selector": "enumMember",
+            "format": ["UPPER_CASE"]
+        },
+        {
             "selector": "parameter",
             "format": ["camelCase"],
             "leadingUnderscore": "allow"
         },
-
         {
             "selector": "memberLike",
             "modifiers": ["private"],


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes https://github.com/pxblue/angular-design-patterns/issues/4

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Introduce a naming convention for enums.  Use UPPER_CASE for enumMembers.
